### PR TITLE
feat: add email digest dry run

### DIFF
--- a/notify.py
+++ b/notify.py
@@ -13,9 +13,11 @@ Email contains two sections:
 import os
 import re
 import smtplib
+import argparse
 import logging
 import time
 from datetime import date, timedelta
+from pathlib import Path
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from dotenv import load_dotenv
@@ -44,6 +46,7 @@ EMAIL_BATCH_SIZE      = int(os.getenv("EMAIL_BATCH_SIZE", "30"))
 EMAIL_BATCH_PAUSE_SEC = int(os.getenv("EMAIL_BATCH_PAUSE_SEC", "360"))
 
 RECENT_DAYS = 7   # Only include opportunities added within this many days
+EMAIL_PREVIEW_PATH = Path(__file__).resolve().parent / "email_preview.html"
 
 SHEET_URL       = f"https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/edit"
 FUNDRAISING_DOC = "https://docs.google.com/document/d/1SqxaAg4tvuWp3LgGzqSSSw4_bxBWHmgmrQ9IyyKHtE8/edit"
@@ -347,6 +350,19 @@ def build_html(nigeria_opps, intl_opps):
 
 # ── Send ─────────────────────────────────────────────────────────────────────
 
+def build_subject(nigeria_opps, intl_opps):
+    total = len(nigeria_opps) + len(intl_opps)
+    return f"ScoutBot Weekly — {total} Fresh Opportunities ({date.today().strftime('%b %d')})"
+
+
+def write_email_preview(html, subject, recipients, preview_path=EMAIL_PREVIEW_PATH):
+    preview_path.write_text(html, encoding="utf-8")
+    print(f"Subject: {subject}")
+    print(f"Recipients: {len(recipients)}")
+    print(f"HTML preview written to: {preview_path.name}")
+    logger.info(f"notify: Dry run preview written to {preview_path}.")
+    return preview_path
+
 def _build_personal_email(html_body, subject, recipient_email):
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
@@ -364,8 +380,7 @@ def send_email(nigeria_opps, intl_opps, recipients):
         logger.warning("notify: No recipients.")
         return False
 
-    total   = len(nigeria_opps) + len(intl_opps)
-    subject = f"ScoutBot Weekly — {total} Fresh Opportunities ({date.today().strftime('%b %d')})"
+    subject = build_subject(nigeria_opps, intl_opps)
     html    = build_html(nigeria_opps, intl_opps)
 
     batches       = [recipients[i:i + EMAIL_BATCH_SIZE]
@@ -409,17 +424,41 @@ def send_email(nigeria_opps, intl_opps, recipients):
     return successes > 0
 
 
-def main():
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+def run_notify(dry_run=False):
     nigeria_opps = fetch_recent_from_tab("Nigeria",       limit=25)
     intl_opps    = fetch_recent_from_tab("International", limit=25)
 
-    if not nigeria_opps and not intl_opps:
+    if not nigeria_opps and not intl_opps and not dry_run:
         logger.warning("notify: No recent opportunities. No email sent.")
-        return
+        return False
+    if not nigeria_opps and not intl_opps:
+        logger.warning("notify: No recent opportunities; writing empty dry-run preview.")
 
     recipients = build_recipient_list()
-    send_email(nigeria_opps, intl_opps, recipients)
+
+    if dry_run:
+        subject = build_subject(nigeria_opps, intl_opps)
+        html = build_html(nigeria_opps, intl_opps)
+        write_email_preview(html, subject, recipients)
+        return True
+
+    return send_email(nigeria_opps, intl_opps, recipients)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="ScoutBot weekly email digest sender")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build email_preview.html and print metadata without connecting to SMTP",
+    )
+    return parser.parse_args()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = parse_args()
+    run_notify(dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -14,6 +14,7 @@ Usage:
   python run.py --schedule   # run on schedule (12:00 PM WAT, every day)
   python run.py --scrape     # only scrape + update sheet
   python run.py --notify     # only send email digest
+  python run.py --notify --dry-run  # write email_preview.html without SMTP
 """
 
 import argparse
@@ -65,13 +66,19 @@ def run_cleanup():
         log.error(f"Cleanup error: {exc}")
 
 
-def run_notify():
+def run_notify(dry_run=False):
     """Read fresh subscribers + open opps, then send the digest."""
-    log.info("▶ Sending digest emails…")
+    if dry_run:
+        log.info("▶ Building digest email preview…")
+    else:
+        log.info("▶ Sending digest emails…")
     try:
         from notify import run_notify as _notify
-        _notify()
-        log.info("✓ Digest sent.")
+        _notify(dry_run=dry_run)
+        if dry_run:
+            log.info("✓ Digest preview written.")
+        else:
+            log.info("✓ Digest sent.")
     except Exception as exc:
         log.error(f"Notify error: {exc}")
 
@@ -101,6 +108,10 @@ def parse_args():
         "--notify", action="store_true",
         help="Only send the email digest (no scrape)"
     )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="With --notify, build email_preview.html and print metadata without SMTP"
+    )
     return parser.parse_args()
 
 
@@ -112,7 +123,7 @@ def main():
         run_cleanup()
 
     elif args.notify:
-        run_notify()
+        run_notify(dry_run=args.dry_run)
 
     elif args.schedule:
         log.info(

--- a/tests/test_notify_dry_run.py
+++ b/tests/test_notify_dry_run.py
@@ -1,0 +1,43 @@
+import contextlib
+import io
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+sys.modules.setdefault(
+    "dotenv",
+    types.SimpleNamespace(load_dotenv=lambda *args, **kwargs: None),
+)
+
+import notify
+
+
+class NotifyDryRunTests(unittest.TestCase):
+    def test_write_email_preview_writes_file_and_metadata(self):
+        with TemporaryDirectory() as tmpdir:
+            preview_path = Path(tmpdir) / "email_preview.html"
+            output = io.StringIO()
+
+            with contextlib.redirect_stdout(output):
+                notify.write_email_preview(
+                    "<html><body>Preview</body></html>",
+                    "ScoutBot Weekly — 2 Fresh Opportunities (Jun 08)",
+                    ["one@example.com", "two@example.com"],
+                    preview_path=preview_path,
+                )
+
+            self.assertEqual(
+                preview_path.read_text(encoding="utf-8"),
+                "<html><body>Preview</body></html>",
+            )
+            stdout = output.getvalue()
+            self.assertIn("Subject: ScoutBot Weekly", stdout)
+            self.assertIn("Recipients: 2", stdout)
+            self.assertIn("HTML preview written to: email_preview.html", stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--dry-run` support to `notify.py` and `run.py --notify`
- build the same digest subject/html used by the live send path and write it to `email_preview.html`
- print the subject, recipient count, and preview filename without opening an SMTP connection
- add a small regression test for the preview writer

Fixes #36

## Testing
- `python3 -m py_compile run.py notify.py tests/test_notify_dry_run.py`
- `python3 -m unittest tests.test_notify_dry_run`
- `git diff --check`
