### PR TITLE
fix: improve deadline extraction

### DIFF
--- a/scoutbot/spiders/opportunities_spider.py
+++ b/scoutbot/spiders/opportunities_spider.py
@@ -165,13 +165,25 @@ def infer_edu(text):
 
 
 def extract_deadline(text):
+    if re.search(r"\brolling admissions?\b|\bapplications reviewed monthly\b", text, re.IGNORECASE):
+        return "Rolling"
+
+    month_expr = (
+        r"(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|"
+        r"jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
+        r"nov(?:ember)?|dec(?:ember)?)"
+    )
+    date_patterns = [
+        r"\d{1,2}/\d{1,2}/\d{4}",
+        rf"\d{{1,2}}(?:st|nd|rd|th)?\s+{month_expr}\s+\d{{4}}",
+        rf"{month_expr}\s+\d{{1,2}},?\s*\d{{4}}",
+        rf"{month_expr}\s+\d{{1,2}}",
+    ]
+    date_expr = "|".join(f"(?:{pattern})" for pattern in date_patterns)
     patterns = [
-        r"deadline[:\s]+([A-Za-z]+ \d{1,2},?\s*\d{4})",
-        r"apply by[:\s]+([A-Za-z]+ \d{1,2},?\s*\d{4})",
-        r"closes?[:\s]+([A-Za-z]+ \d{1,2},?\s*\d{4})",
-        r"closing date[:\s]+([A-Za-z]+ \d{1,2},?\s*\d{4})",
-        r"(\d{1,2} [A-Za-z]+ \d{4})",
-        r"([A-Za-z]+ \d{1,2},?\s*\d{4})",
+        rf"(?:applications?\s+close(?:s)?\s+on|submissions?\s+accepted\s+until|accepted\s+until)\s+({date_expr})",
+        rf"(?:deadline|apply by|closes?|closing date)[:\s]+({date_expr})",
+        rf"({date_expr})",
     ]
     for p in patterns:
         m = re.search(p, text, re.IGNORECASE)

--- a/tests/test_deadline_extraction.py
+++ b/tests/test_deadline_extraction.py
@@ -1,0 +1,54 @@
+import sys
+import types
+import unittest
+
+
+class _ScrapyStub(types.SimpleNamespace):
+    class Item(dict):
+        pass
+
+    class Spider:
+        pass
+
+    @staticmethod
+    def Field(*args, **kwargs):
+        return None
+
+    @staticmethod
+    def Request(*args, **kwargs):
+        return None
+
+
+sys.modules.setdefault("scrapy", _ScrapyStub())
+
+from scoutbot.spiders.opportunities_spider import extract_deadline
+
+
+class DeadlineExtractionTests(unittest.TestCase):
+    def test_extracts_numeric_deadline(self):
+        self.assertEqual(
+            extract_deadline("Applications close on 30/06/2025"),
+            "30/06/2025",
+        )
+
+    def test_extracts_ordinal_day_deadline(self):
+        self.assertEqual(
+            extract_deadline("Deadline: 30th June 2025"),
+            "30th June 2025",
+        )
+
+    def test_extracts_month_day_without_year(self):
+        self.assertEqual(
+            extract_deadline("Submissions accepted until June 30"),
+            "June 30",
+        )
+
+    def test_extracts_rolling_admissions(self):
+        self.assertEqual(
+            extract_deadline("Rolling admissions — applications reviewed monthly"),
+            "Rolling",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add deadline extraction support for numeric dates like `30/06/2025`
- handle ordinal day formats like `30th June 2025`
- capture month/day deadlines from `accepted until June 30`
- return `Rolling` for rolling admissions/reviewed-monthly copy
- add focused regression tests for the formats listed in the issue

Fixes #33

## Testing
- `python3 -m unittest tests.test_deadline_extraction`
- `python3 -m py_compile scoutbot/spiders/opportunities_spider.py tests/test_deadline_extraction.py`
- `git diff --check`
