### PR TITLE
fixed extract deadline

### DIFF
--- a/scoutbot/spiders/opportunities_spider.py
+++ b/scoutbot/spiders/opportunities_spider.py
@@ -166,6 +166,10 @@ def infer_edu(text):
 
 def extract_deadline(text):
     patterns = [
+        r"applications?\s+close\s+on\s+(\d{1,2}/\d{1,2}/\d{4})",
+        r"deadline[:\s]+(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})",
+        r"submissions?\s+accepted\s+until\s+([A-Za-z]+\s+\d{1,2})",
+        r"(rolling admissions?)",
         r"deadline[:\s]+([A-Za-z]+ \d{1,2},?\s*\d{4})",
         r"apply by[:\s]+([A-Za-z]+ \d{1,2},?\s*\d{4})",
         r"closes?[:\s]+([A-Za-z]+ \d{1,2},?\s*\d{4})",
@@ -173,10 +177,12 @@ def extract_deadline(text):
         r"(\d{1,2} [A-Za-z]+ \d{4})",
         r"([A-Za-z]+ \d{1,2},?\s*\d{4})",
     ]
+
     for p in patterns:
         m = re.search(p, text, re.IGNORECASE)
         if m:
             return m.group(1).strip()
+
     return ""
 
 


### PR DESCRIPTION
## 📋 What does this PR do?

Improves deadline extraction in `opportunities_spider.py` by adding support for additional deadline formats that were previously missed.

### Added support for:

* `Applications close on 30/06/2025`
* `Deadline: 30th June 2025`
* `Submissions accepted until June 30`
* `Rolling admissions — applications reviewed monthly`

The new regex patterns are checked before the existing generic patterns to ensure more accurate matching.

## 🔗 Related Issue

Closes #33 

## 🧪 How was this tested?

Tested `extract_deadline()` with the following sample inputs:

* `Applications close on 30/06/2025` → `30/06/2025`
* `Deadline: 30th June 2025` → `30th June 2025`
* `Submissions accepted until June 30` → `June 30`
* `Rolling admissions — applications reviewed monthly` → `Rolling admissions`

Verified that existing supported formats continue to be extracted correctly.

## 📸 Screenshots (if UI changes)

N/A – no UI changes.

## ✅ Checklist

* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] Tested the changes locally
* [x] Added support for additional deadline formats
