### PR TITLE
ci: add pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,4 +25,4 @@ jobs:
           pip install pytest
 
       - name: Run tests
-        run: pytest
+        run: python -m pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,28 @@
+name: Pytest
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,2 @@
+def test_project_imports():
+    import scoutbot


### PR DESCRIPTION
Closes #46

 Summary:
1) Added a GitHub Actions workflow to run pytest on pushes and pull requests.
2)Added a small starter import test so the workflow has a baseline test to run.

 Testing:
-1)Ran pytest locally.